### PR TITLE
remove unused streamlit-toggle import

### DIFF
--- a/streamlit_vertical_slider/__init__.py
+++ b/streamlit_vertical_slider/__init__.py
@@ -3,7 +3,6 @@ from idna import valid_contextj
 import streamlit.components.v1 as components
 import streamlit as st
 import altair as alt
-import streamlit_toggle as sts
 from typing import Literal
 
 


### PR DESCRIPTION
There is an import that is not used

https://github.com/sqlinsights/streamlit-vertical-slider/blob/737b6a88c1bbd55b157a49ed40ba133a81b20e8a/streamlit_vertical_slider/__init__.py#L6

`sts` is never used, and neither `streamlit_toggle`, in the project

https://github.com/search?q=repo%3Asqlinsights%2Fstreamlit-vertical-slider%20sts&type=code

https://github.com/search?q=repo%3Asqlinsights%2Fstreamlit-vertical-slider%20streamlit_toggle&type=code

ref: https://github.com/sqlinsights/streamlit-vertical-slider/issues/6