### PR TITLE
set encoding utf-8 for reading readme in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 from pathlib import Path
 
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
+long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 setuptools.setup(
     name="streamlit_vertical_slider",


### PR DESCRIPTION
Under Windows, while building the wheel:

```
...
                   INFO     Traceback (most recent call last):                                                                                                                                                      
                   INFO       File "<string>", line 2, in <module>                                                                                                                                                  
                   INFO       File "<pip-setuptools-caller>", line 34, in <module>                                                                                                                                  
                   INFO       File "C:\---\setup.py", line 7, in <module>                                                                           
                   INFO         long_description = (this_directory / "README.md").read_text()                                                                                                                       
                   INFO                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                       
...                                                     
                   INFO         return codecs.charmap_decode(input,self.errors,decoding_table)[0]                                                                                                                   
                   INFO                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                      
                   INFO     UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 115: character maps to <undefined>                                                                               
                   INFO     error: subprocess-exited-with-error                                                                                                                                                     
...
```

In `setup.py` the line:

https://github.com/sqlinsights/streamlit-vertical-slider/blob/737b6a88c1bbd55b157a49ed40ba133a81b20e8a/setup.py#L7

is trying to open the `README.md` file that has at least 1 `utf-8` character,

and therefore it is giving an error, for Windows:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 115: character maps to <undefined>
```

You can search for the error line, and see people struggling with that:

* https://stackoverflow.com/questions/9233027/unicodedecodeerror-charmap-codec-cant-decode-byte-x-in-position-y-character

Setting the encoding to `utf-8` will fix this for Windows and keep unix platforms working.